### PR TITLE
Fix exception when trying to read profiles stored in binary format

### DIFF
--- a/FSProfiles.Common/Classes/FolderProcessorBase.cs
+++ b/FSProfiles.Common/Classes/FolderProcessorBase.cs
@@ -13,11 +13,22 @@ public interface IFolderProcessor
 
 public abstract class FolderProcessorBase
 {
+    bool IsXmlFile(string fileName)
+    {
+      if (string.IsNullOrWhiteSpace(fileName))
+        return false;
+      var line = new byte[6];
+      using (var fs = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+        fs.Read(line, 0, 6);
+      return System.Text.Encoding.Default.GetString(line).StartsWith("<?xml");
+    }
+
     public DetectedProfile? ProcessFile(string fileName)
     {
-        var fileContent = File.ReadAllLines(fileName).ToList();
-        if (!fileContent[0].StartsWith("<?xml")) return null; //not a processable file 
+        if (!IsXmlFile(fileName))
+          return null; //not a processable file
 
+        var fileContent = File.ReadAllLines(fileName).ToList();
         //Add new root object so contents are processable as a normal XML
         fileContent.Insert(1, @"<ControllerDefinition>");
         fileContent.Add(@"</ControllerDefinition>");


### PR DESCRIPTION
Hi Ian,

In my MSFS "Store" version "wgs" profiles there are some files that are in a binary format. They "look" like profile files, with the long GUID name, but they're not text or XML.

(Not entirely sure what they are... range from 2 to 870 KB, have `LZMA` header but 7-Zip can't open them.  🤷🏼 )

`File.Read[All]Lines()` returns an empty array for these binary files, leading to an exception when trying to get the first member with `fileContent[0]`.

This caused an exception dialog to come up when the program tried to scan the profiles folder, asking me if I'd like to continue anyway or quit (and a "Details" drop-down showing the call stack... nice!).

Admittedly breaking the check out into it's own read operation is perhaps overkill, and there are certainly other ways to trap or check for an empty result from `ReadLines`. But this way does avoid potentially trying to read in a while binary file when just the first few bytes matter.

Incidentally, a similar project ([FS2020Control](https://github.com/dmenne/FS2020Control)) I tried had the [same issue](https://github.com/dmenne/FS2020Control/pull/4). Perhaps something changed with an FS20 update that started creating these binary files.

And nice program, thanks for publishing!

Best,
-Max
